### PR TITLE
Fix Together AI retries

### DIFF
--- a/api/test_api_sender.py
+++ b/api/test_api_sender.py
@@ -1,13 +1,20 @@
 import requests
 
-# Test GET /ping/
-response = requests.get("http://127.0.0.1:8000/ping/")
-print(response.json())  # Should return {"status": "alive", "message": "API is running!"}
 
-# Test POST /echo/
-test_data = {"key": "value", "test": True}
-response = requests.post(
-    "http://127.0.0.1:8000/echo/",
-    json=test_data
-)
-print(response.json())  # Should echo back your data with a success message
+def main():
+    """Simple helper script to exercise the FastAPI endpoints."""
+    # Test GET /ping/
+    response = requests.get("http://127.0.0.1:8000/ping/")
+    print(response.json())  # {"status": "alive", "message": "API is running!"}
+
+    # Test POST /echo/
+    test_data = {"key": "value", "test": True}
+    response = requests.post(
+        "http://127.0.0.1:8000/echo/",
+        json=test_data,
+    )
+    print(response.json())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- ensure Together API client waits for full non-streaming response
- use retry wrapper for topic, subtopic, and detail extraction

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6858d992074483329b1f559dd1067e03